### PR TITLE
spec (add spec) Add initial backend service YAML spec.

### DIFF
--- a/spec/apollo-server-spec.yaml
+++ b/spec/apollo-server-spec.yaml
@@ -1,18 +1,18 @@
 swagger: "2.0"
 info:
-  description: "This is the backend component API. Visit the link for an interactive playground to execute requests."
+  description: "This is the backend component API exposing a GraphQL server. The [GraphQL spec](https://spec.graphql.org/June2018/) dives deep into the philosophy of GraphQL. This spec models and showcases the request/response formats expected from the backend service."
   version: "1.0.0"
   title: "Road Rules Search Engine"
 tags:
   - name: "Backend service"
 schemes:
-  - "https"
+  - "http"
 paths:
   /:
     post:
       tags:
-        - "Root"
-      summary: "Base path"
+        - "Backend service"
+      summary: "GraphQL endpoint"
       description: "Base path handles any incoming request and re-routes it to the requested resolver."
       consumes:
         - "application/json"

--- a/spec/apollo-server-spec.yaml
+++ b/spec/apollo-server-spec.yaml
@@ -33,10 +33,6 @@ definitions:
   Request:
     type: "object"
     properties:
-      operationName:
-        type: "string"
-        description: "The name of the GraphQL resolver being requested."
-        example: "articles"
       query:
         type: "string"
         description: "A GraphQL request containing required attributes."

--- a/spec/apollo-server-spec.yaml
+++ b/spec/apollo-server-spec.yaml
@@ -1,0 +1,56 @@
+swagger: "2.0"
+info:
+  description: "This is the backend component API. Visit the link for an interactive playground to execute requests."
+  version: "1.0.0"
+  title: "Road Rules Search Engine"
+tags:
+  - name: "Backend service"
+schemes:
+  - "https"
+paths:
+  /:
+    post:
+      tags:
+        - "Root"
+      summary: "Base path"
+      description: "Base path handles any incoming request and re-routes it to the requested resolver."
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "Any GraphQL request ( query/mutation/subscription )"
+          schema:
+            $ref: '#/definitions/Request'
+      responses:
+        "200":
+          description: "Default response format"
+          schema:
+            $ref: '#/definitions/Response'
+definitions:
+  Request:
+    type: "object"
+    properties:
+      operationName:
+        type: "string"
+        description: "The name of the GraphQL resolver being requested."
+        example: "articles"
+      query:
+        type: "string"
+        description: "A GraphQL request containing required attributes."
+        example: "query articles(search: String! limit: Int) { id number content }"
+      variables:
+        type: "object"
+        description: "An object containing all required variables by the operation."
+        example: { search: "test", limit: 5 }
+  Response:
+    type: "object"
+    properties:
+      data:
+        type: "object"
+      errors:
+        type: "array"
+        items:
+          type: "object"


### PR DESCRIPTION
+ Created spec/ folder to group the specs of the different available components in the application.
Added the `apollo-server-spec.yaml` to describe request/response formats from the backend service.