### PR TITLE
bugfix (cache) Add expiration to cached articles to flush them periodically.

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,9 @@
 import { ApolloServer } from 'apollo-server-express'
 import { importSchema } from 'graphql-import'
+import { promisify } from 'util'
 import express from 'express'
 import path from 'path'
-import redis from 'async-redis'
+import redis from 'redis'
 import localCache from './utils/in-memory-cache'
 import resolvers from './resolvers'
 import { PORT, REDIS_IP, REDIS_PORT } from './config'
@@ -11,9 +12,16 @@ const typeDefs = importSchema(path.join(__dirname, './typedefs/index.graphql'))
 
 // If you don't want to spin up a local Redis server, make sure to avoid
 // REDIS_IP and REDIS_PORT .env variables declared to default to an in-memory storage
-const cache = REDIS_IP && REDIS_PORT
-  ? redis.createClient({ host: REDIS_IP, port: REDIS_PORT })
-  : localCache
+let cache
+if (REDIS_IP && REDIS_PORT) {
+  cache = redis.createClient({ host: REDIS_IP, port: REDIS_PORT })
+
+  // Make Redis ops asynchronous.
+  cache.get = promisify(cache.get).bind(cache)
+  cache.exists = promisify(cache.exists).bind(cache)
+} else {
+  cache = localCache
+}
 
 const server = new ApolloServer({
   typeDefs,

--- a/server/package.json
+++ b/server/package.json
@@ -12,14 +12,14 @@
     "@babel/core": "^7.10.5",
     "@babel/node": "^7.10.5",
     "@babel/preset-env": "^7.10.4",
-    "async-redis": "^1.1.7",
     "apollo-server-express": "^2.16.1",
     "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "graphql": "^15.3.0",
     "graphql-import": "^1.0.2",
-    "nodemon": "^2.0.4"
+    "nodemon": "^2.0.4",
+    "redis": "^3.0.2"
   },
   "devDependencies": {
     "@jest/globals": "^26.4.0",

--- a/server/resolvers/article/queries.js
+++ b/server/resolvers/article/queries.js
@@ -32,6 +32,7 @@ const articleQueries = {
       delete article.wordCount
 
       cache.set(article.id, JSON.stringify(article))
+      cache.expire(article.id, 60 * 60 * 24)
 
       articles.push(article)
     }

--- a/server/tests/queries.test.js
+++ b/server/tests/queries.test.js
@@ -8,10 +8,7 @@ import { createTestClient } from 'apollo-server-testing'
 import resolvers from '../resolvers'
 import { databaseApi, searchApi } from '../endpoints'
 import { mockArticles, mockArticlesInCache } from './mocks'
-
-// In-memory cache to mock redis operations
-const cache = new Map()
-cache.exists = key => cache.has(key)
+import cache from '../utils/in-memory-cache'
 
 const typeDefs = importSchema(path.join(__dirname, '../typedefs/index.graphql'))
 const server = new ApolloServer({

--- a/server/utils/in-memory-cache.js
+++ b/server/utils/in-memory-cache.js
@@ -1,6 +1,7 @@
 const localCache = new Map()
 
 localCache.exists = key => localCache.has(key)
+localCache.expire = (key, ttl) => setTimeout(() => localCache.delete(key), ttl * 1000)
 localCache.on = (_, connection) => connection('🧶  No local Redis instance found... Defaulting to an in-memory cache storage.')
 
 export default localCache

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2005,14 +2005,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
-async-redis@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/async-redis/-/async-redis-1.1.7.tgz#d9e236afa594bdc7b6e00f5b03f1d2304c017d50"
-  integrity sha512-phpZe2/U+Ih4Lpy72KWF4+c8gymsUgzg6NV/TZUb8BLNn7soQewFxqcq9nndobfPmzXiuhMLi6GNBiQVIor/EA==
-  dependencies:
-    redis "^2.8.0"
-    redis-commands "^1.3.1"
-
 async-retry@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
@@ -2782,6 +2774,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
+
 depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
@@ -2839,11 +2836,6 @@ dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
-
-double-ended-queue@^2.1.0-0:
-  version "2.1.0-0"
-  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
-  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -5418,24 +5410,32 @@ readdirp@~3.4.0:
   dependencies:
     picomatch "^2.2.1"
 
-redis-commands@^1.2.0, redis-commands@^1.3.1:
+redis-commands@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.6.0.tgz#36d4ca42ae9ed29815cdb30ad9f97982eba1ce23"
   integrity sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==
 
-redis-parser@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
-  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
 
-redis@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
-  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
   dependencies:
-    double-ended-queue "^2.1.0-0"
-    redis-commands "^1.2.0"
-    redis-parser "^2.6.0"
+    redis-errors "^1.0.0"
+
+redis@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.0.2.tgz#bd47067b8a4a3e6a2e556e57f71cc82c7360150a"
+  integrity sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==
+  dependencies:
+    denque "^1.4.1"
+    redis-commands "^1.5.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
 
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
+ Added `.expire` to every article set to last at most a day on the cache before being flushed. [resolvers/article/index.js]

+ Had to switch Redis dependency from `async-redis` to `redis` since the first one hasn't been updated in a while and lacks expiration support. Plus `redis` library is the official one suggested on Redis documentation. [package.json, yarn.lock]

+ The `redis` dependency comes with the hassle of not supporting asynchronous calls out of the box, but, as per their documentation, in order to force it to be asynchronous, the built-in `util` library from Node.js allows us to wrap the Redis ops in asynchronous calls. [index.js]

Closes #85 