### PR TITLE
bugfix (article card) Set maxHeight on article cards to fix height issue.

### DIFF
--- a/app/src/views/search-engine/components/articles-list/styles.js
+++ b/app/src/views/search-engine/components/articles-list/styles.js
@@ -9,7 +9,8 @@ const styles = makeStyles(() => ({
   },
   cardContent: {
     whiteSpace: 'pre-wrap',
-    marginBottom: 15
+    marginBottom: 15,
+    maxHeight: '20vh'
   }
 }))
 


### PR DESCRIPTION
+ Added a `maxHeight` attribute to the card content to limit the size of all cards.

Closes #84 